### PR TITLE
changes SnapshotMessage->SnapshotMessageBase; updates timestamp type as optional - moves it

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openlaw/snapshot-js-erc712",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Implementation of ERC-712 structure signatures.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/utils/snapshotHub.ts
+++ b/utils/snapshotHub.ts
@@ -117,7 +117,10 @@ export type SnapshotVoteData = {
   };
 } & SnapshotCoreProposalData;
 
-export type SnapshotMessage = {
+/**
+ * Common arguments for functions which build messages
+ */
+export type SnapshotMessageBase = {
   name: SnapshotCoreProposalPayloadData["name"];
   body: SnapshotCoreProposalPayloadData["body"];
   metadata: SnapshotCoreProposalPayloadData["metadata"];
@@ -126,7 +129,6 @@ export type SnapshotMessage = {
   actionId: SnapshotCoreProposalData["actionId"];
   chainId: SnapshotCoreProposalData["chainId"];
   verifyingContract: SnapshotCoreProposalData["verifyingContract"];
-  timestamp: SnapshotCoreProposalData["timestamp"];
 };
 
 export type SnapshotMessageProposal = {
@@ -138,7 +140,13 @@ export type SnapshotMessageProposal = {
    * Ethereum block to use (e.g. latest).
    */
   snapshot: number;
-} & SnapshotMessage;
+  /**
+   * Optional timestamp string (seconds).
+   * Providing the timestamp is helpful in cases where generated
+   * hashes need to match (i.e. a way to use the same data).
+   */
+  timestamp?: SnapshotCoreProposalData["timestamp"];
+} & SnapshotMessageBase;
 
 export type SnapshotMessageVote = {
   /**
@@ -180,7 +188,7 @@ const getVoteChoiceIndex = (choice: VoteChoices) =>
   VOTE_CHOICES.findIndex((c) => c === choice) + 1;
 
 export const buildDraftMessage = async (
-  message: SnapshotMessage,
+  message: SnapshotMessageBase,
   snapshotHubURL: string
 ): Promise<SnapshotDraftData> => {
   try {


### PR DESCRIPTION
**Changes**

- Moves `timestamp` attribute to be specific to Proposals.
- Makes `timestamp` attribute optional (writes comments)
- Renames `SnapshotMessage`->`SnapshotMessageBase` to be more clear.