### PR TITLE
Change incorrect type name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openlaw/snapshot-js-erc712",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Implementation of ERC-712 structure signatures.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/utils/snapshotHub.ts
+++ b/utils/snapshotHub.ts
@@ -189,7 +189,7 @@ export type SnapshotSubmitBaseReturn = {
   uniqueId: string;
 };
 
-export type SnapshotSubmitDraftReturn = {
+export type SnapshotSubmitProposalReturn = {
   uniqueIdDraft: string;
 } & SnapshotSubmitBaseReturn;
 
@@ -299,12 +299,12 @@ export const buildVoteMessage = async (
   }
 };
 
-export const submitMessage = <ReturnData extends SnapshotSubmitBaseReturn>(
+export const submitMessage = <T extends SnapshotSubmitBaseReturn>(
   snapshotHubURL: string,
   address: string,
   message: SnapshotDraftData | SnapshotProposalData | SnapshotVoteData,
   signature: string
-): Promise<{ data: ReturnData }> => {
+): Promise<{ data: T }> => {
   const data = {
     address,
     msg: JSON.stringify(message),


### PR DESCRIPTION
**Changes**

- `SnapshotSubmitDraftReturn` -> `SnapshotSubmitProposalReturn`
- `<ReturnData extends SnapshotSubmitBaseReturn>` -> `<T extends SnapshotSubmitBaseReturn>`