### PR TITLE
Makes start and end current, not based on draft timestamp

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openlaw/snapshot-js-erc712",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "Implementation of ERC-712 structure signatures.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/utils/snapshotHub.ts
+++ b/utils/snapshotHub.ts
@@ -63,16 +63,18 @@ export const buildProposalMessage = async (
     const timestamp = message.timestamp
       ? parseInt(message.timestamp)
       : getTimestampSeconds();
+    const voteStartTimestamp: number = getTimestampSeconds();
+
     const { data } = await getApiStatus(snapshotHubURL);
 
     return {
       payload: {
         body: message.body,
         choices: VOTE_CHOICES,
-        end: timestamp + message.votingTimeSeconds,
+        end: voteStartTimestamp + message.votingTimeSeconds,
         metadata: message.metadata,
         name: message.name,
-        start: timestamp,
+        start: voteStartTimestamp,
         snapshot: message.snapshot,
       },
       actionId: message.actionId,


### PR DESCRIPTION
Fixes #15 

**Changes**

- Changes `start`, `end` timestamps for Proposals to be created when function runs (based on `Date.now`), not the old Draft's `timestamp`