### PR TITLE
Sig data updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openlaw/snapshot-js-erc712",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "Implementation of ERC-712 structure signatures.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/types.ts
+++ b/types.ts
@@ -11,3 +11,43 @@ export type PrepareVoteProposalData = {
   space: string;
   timestamp: number;
 };
+
+export type PrepareProposalMessageData = {
+  timestamp: number;
+  space: string;
+  payload: PrepareProposalPayloadData;
+};
+
+export type PrepareProposalPayloadData = {
+  body: string;
+  choices: string[];
+  end: number;
+  name: string;
+  snapshot: string;
+  start: number;
+};
+
+export type PrepareVoteMessageData = {
+  timestamp: number;
+  payload: PrepareVoteMessagePayloadData;
+};
+
+export type PrepareVoteMessagePayloadData = {
+  choice: 1 | 2;
+  proposalHash: string;
+};
+
+export type PrepareProposalMessageReturn = {
+  timestamp: number;
+  spaceHash: string;
+  payload: PrepareProposalPayloadReturn;
+};
+
+export type PrepareProposalPayloadReturn = {
+  bodyHash: string;
+  choices: string[];
+  end: number;
+  nameHash: string;
+  snapshot: string;
+  start: number;
+};

--- a/types.ts
+++ b/types.ts
@@ -1,3 +1,5 @@
+import { SnapshotType } from "./utils";
+
 export type PrepareVoteProposalData = {
   payload: {
     body: string;
@@ -12,8 +14,20 @@ export type PrepareVoteProposalData = {
   timestamp: number;
 };
 
+export type PrepareDraftMessageData = {
+  timestamp: number | string;
+  space: string;
+  payload: PrepareDraftMessagePayloadData;
+};
+
+export type PrepareDraftMessagePayloadData = {
+  body: string;
+  choices: string[];
+  name: string;
+};
+
 export type PrepareProposalMessageData = {
-  timestamp: number;
+  timestamp: number | string;
   space: string;
   payload: PrepareProposalPayloadData;
 };
@@ -23,18 +37,30 @@ export type PrepareProposalPayloadData = {
   choices: string[];
   end: number;
   name: string;
-  snapshot: string;
+  snapshot: string | number;
   start: number;
 };
 
 export type PrepareVoteMessageData = {
-  timestamp: number;
+  timestamp: number | string;
   payload: PrepareVoteMessagePayloadData;
 };
 
 export type PrepareVoteMessagePayloadData = {
   choice: 1 | 2;
   proposalHash: string;
+};
+
+export type PrepareDraftMessageReturn = {
+  timestamp: number;
+  spaceHash: string;
+  payload: PrepareDraftMessagePayloadReturn;
+};
+
+export type PrepareDraftMessagePayloadReturn = {
+  bodyHash: string;
+  choices: string[];
+  nameHash: string;
 };
 
 export type PrepareProposalMessageReturn = {
@@ -50,4 +76,8 @@ export type PrepareProposalPayloadReturn = {
   nameHash: string;
   snapshot: string;
   start: number;
+};
+
+export type MessageWithType = Record<string, any> & {
+  type: SnapshotType | "result";
 };

--- a/utils/snapshotHub.ts
+++ b/utils/snapshotHub.ts
@@ -1,6 +1,7 @@
 import axios from "axios";
 import {
   CoreProposalVoteChoices,
+  Erc712Data,
   SnapshotDraftData,
   SnapshotMessageBase,
   SnapshotMessageProposal,
@@ -41,13 +42,10 @@ export const buildDraftMessage = async (
         metadata: message.metadata,
         name: message.name,
       },
-      actionId: message.actionId,
-      chainId: message.chainId,
       space: message.space,
       timestamp: getTimestampSeconds().toString(),
       token: message.token,
       type: SnapshotType.draft,
-      verifyingContract: message.verifyingContract,
       version: data.version,
     };
   } catch (error) {
@@ -77,13 +75,10 @@ export const buildProposalMessage = async (
         start: voteStartTimestamp,
         snapshot: message.snapshot,
       },
-      actionId: message.actionId,
-      chainId: message.chainId,
       space: message.space,
       timestamp: timestamp.toString(),
       token: message.token,
       type: SnapshotType.proposal,
-      verifyingContract: message.verifyingContract,
       version: data.version,
     };
   } catch (error) {
@@ -107,13 +102,10 @@ export const buildVoteMessage = async (
         proposalHash: proposal.proposalHash,
         metadata: vote.metadata,
       },
-      actionId: proposal.actionId,
-      chainId: vote.chainId,
       space: proposal.space,
       timestamp: timestamp.toString(),
       token: proposal.token,
       type: SnapshotType.vote,
-      verifyingContract: proposal.verifyingContract,
       version: data.version,
     };
   } catch (error) {
@@ -125,12 +117,14 @@ export const submitMessage = <T extends SnapshotSubmitBaseReturn>(
   snapshotHubURL: string,
   address: string,
   message: SnapshotDraftData | SnapshotProposalData | SnapshotVoteData,
-  signature: string
+  signature: string,
+  erc712Data: Erc712Data
 ): Promise<{ data: T }> => {
   const data = {
     address,
     msg: JSON.stringify(message),
     sig: signature,
+    erc712Data: JSON.stringify(erc712Data),
   };
   return axios.post(`${snapshotHubURL}/api/message`, data, {
     headers: {

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -67,18 +67,6 @@ export type SnapshotCoreProposalData = {
    * Registered space name in the snapshot-hub api
    */
   space: string;
-  /**
-   * Intended contract address to use this data. For ERC712 signature verification.
-   */
-  actionId: string;
-  /**
-   * Ethereum network ID. For ERC712 signature verification.
-   */
-  chainId: number;
-  /**
-   * The contract address which will verify the signature. For ERC712 signature verification.
-   */
-  verifyingContract: string;
 };
 
 export type SnapshotDraftData = {
@@ -132,9 +120,6 @@ export type SnapshotMessageBase = {
   metadata: SnapshotCoreProposalPayloadData["metadata"];
   token: SnapshotCoreProposalData["token"];
   space: SnapshotCoreProposalData["space"];
-  actionId: SnapshotCoreProposalData["actionId"];
-  chainId: SnapshotCoreProposalData["chainId"];
-  verifyingContract: SnapshotCoreProposalData["verifyingContract"];
 };
 
 export type SnapshotMessageProposal = {
@@ -170,11 +155,9 @@ export type SnapshotMessageVote = {
 };
 
 export type SnapshotVoteProposal = {
-  actionId: SnapshotCoreProposalData["actionId"];
   proposalHash: SnapshotVoteData["payload"]["proposalHash"];
   space: SnapshotCoreProposalData["space"];
   token: SnapshotCoreProposalData["token"];
-  verifyingContract: SnapshotCoreProposalData["verifyingContract"];
 };
 
 export type SnapshotSubmitBaseReturn = {
@@ -313,3 +296,10 @@ export type SnapshotVoteResponse = Record<
  * @note Votes are inside an array, unlike the Proposals object.
  */
 export type SnapshotVotesResponse = SnapshotVoteResponse[];
+
+export type Erc712Data = {
+  actionId: string;
+  chainId: number;
+  verifyingContract: string;
+  message: Record<string, any>;
+};


### PR DESCRIPTION
**Changes**

This update provides fixes to match `laoland` for signing and validation by the smart contract, and preparing data for Snapshot Hub.

- Separates ERC-712 data from Snapshot Hub readable data
- Better types for `prepare...Message()`
- Timestamp parsed for convenience (as Snapshot's is a `string`) to `number` in `prepare...Message()`
- Better handling for case where `Web3.utils.sha3` can return `null` (according to its types, anyway) in `prepare...Message()`
- Bumps version to `1.0.14`