### PR TITLE
Adds export type VoteChoicesIndex and simplifies getting vote index

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -39,7 +39,7 @@ import {
   PrepareVoteProposalData,
 } from "./types";
 import MerkleTree from "./utils/merkleTree";
-import { SnapshotType } from "./utils";
+import { SnapshotType, VoteChoicesIndex } from "./utils";
 
 export const getMessageERC712Hash = (
   message: MessageWithType,
@@ -409,7 +409,7 @@ export const createVote = (
   voteYes: boolean
 ) => {
   const payload = {
-    choice: voteYes ? 1 : 2,
+    choice: voteYes ? VoteChoicesIndex.Yes : VoteChoicesIndex.No,
     account,
     proposalHash,
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openlaw/snapshot-js-erc712",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "Implementation of ERC-712 structure signatures.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/types.ts
+++ b/types.ts
@@ -1,4 +1,4 @@
-import { SnapshotType } from "./utils";
+import { SnapshotType, VoteChoicesIndex } from "./utils";
 
 export type PrepareVoteProposalData = {
   payload: {
@@ -47,7 +47,7 @@ export type PrepareVoteMessageData = {
 };
 
 export type PrepareVoteMessagePayloadData = {
-  choice: 1 | 2;
+  choice: VoteChoicesIndex;
   proposalHash: string;
 };
 

--- a/utils/snapshotHub.ts
+++ b/utils/snapshotHub.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+
 import {
   CoreProposalVoteChoices,
   Erc712Data,
@@ -12,6 +13,7 @@ import {
   SnapshotVoteData,
   SnapshotVoteProposal,
   VoteChoices,
+  VoteChoicesIndex,
 } from "./types";
 
 /**
@@ -24,9 +26,15 @@ const VOTE_CHOICES: CoreProposalVoteChoices = [VoteChoices.Yes, VoteChoices.No];
 
 const getTimestampSeconds: () => number = () => Math.floor(Date.now() / 1e3);
 
-// @note The snapshot-hub API does not accept falsy choices like index `0`.
-const getVoteChoiceIndex = (choice: VoteChoices) =>
-  VOTE_CHOICES.findIndex((c) => c === choice) + 1;
+const getVoteChoiceIndex = (choice: VoteChoices): VoteChoicesIndex => {
+  const index = VoteChoicesIndex[choice];
+
+  if (!index) {
+    throw new Error("Could not find vote index.");
+  }
+
+  return index;
+};
 
 export const buildDraftMessage = async (
   message: SnapshotMessageBase,

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -3,6 +3,12 @@ export enum VoteChoices {
   Yes = "Yes",
 }
 
+// @note The snapshot-hub API does not accept falsy choices like index `0`.
+export enum VoteChoicesIndex {
+  Yes = 1,
+  No = 2,
+}
+
 export enum SnapshotType {
   draft = "draft",
   proposal = "proposal",
@@ -91,7 +97,7 @@ export type SnapshotVoteData = {
     /**
      * The choice's index
      */
-    choice: number;
+    choice: VoteChoicesIndex;
     /**
      * The proposal's ERC712 hash
      */


### PR DESCRIPTION
**Changes**

- Adds new `enum VoteChoicesIndex` which is more flexible than hardcoded `1 | 2`
- Updates some functions to use `enum VoteChoicesIndex`
- Updates `getVoteChoiceIndex` function to be simpler and handle case where index is not found.