### PR TITLE
Fixes `createVote` not setting `timestamp` and `weight` correctly when no vote

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -487,8 +487,8 @@ export const createVote = ({
   const sigTrimmed: string = sig.trim();
   const noSig: boolean = !sigTrimmed || sigTrimmed === "0x";
   const noWeight: boolean = Number(weight) <= 0 || !weight || noSig;
-  // If no vote, set to `0`. Only allow positive Number.
-  const timestampToUse: number = noSig || noWeight ? 0 : Math.abs(timestamp);
+  // If no `sig`, set to `0`. Only allow positive Number.
+  const timestampToUse: number = noSig ? 0 : Math.abs(timestamp);
 
   // If `weight` is falsey then set choice to `0`, else continue to determine a choice of yes or no.
   const choice: VoteEntry["choice"] = noWeight

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openlaw/snapshot-js-erc712",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Implementation of ERC-712 structure signatures.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/tests/createVote.unit.test.ts
+++ b/tests/createVote.unit.test.ts
@@ -39,7 +39,79 @@ describe("createVote unit tests", () => {
       weight: "100000",
     });
 
-    // Member did not vote
+    // `sig: "0x"`
+    expect(
+      createVote({
+        proposalId: DEFAULT_PROPOSAL_ID,
+        sig: "0x",
+        timestamp: DEFAULT_TIMESTAMP,
+        voteYes: false,
+        weight: "0",
+      })
+    ).toEqual({
+      choice: 0,
+      proposalId: DEFAULT_PROPOSAL_ID,
+      sig: "0x",
+      timestamp: 0,
+      type: "vote",
+      weight: "0",
+    });
+
+    // `sig: ""`
+    expect(
+      createVote({
+        proposalId: DEFAULT_PROPOSAL_ID,
+        sig: "0x",
+        timestamp: DEFAULT_TIMESTAMP,
+        voteYes: false,
+        weight: "0",
+      })
+    ).toEqual({
+      choice: 0,
+      proposalId: DEFAULT_PROPOSAL_ID,
+      sig: "0x",
+      timestamp: 0,
+      type: "vote",
+      weight: "0",
+    });
+
+    // `weight` is positive, `sig: "0x"`
+    expect(
+      createVote({
+        proposalId: DEFAULT_PROPOSAL_ID,
+        sig: "0x",
+        timestamp: DEFAULT_TIMESTAMP,
+        voteYes: false,
+        weight: "100000",
+      })
+    ).toEqual({
+      choice: 0,
+      proposalId: DEFAULT_PROPOSAL_ID,
+      sig: "0x",
+      timestamp: 0,
+      type: "vote",
+      weight: "0",
+    });
+
+    // `weight` is positive, `sig: ""`
+    expect(
+      createVote({
+        proposalId: DEFAULT_PROPOSAL_ID,
+        sig: "0x",
+        timestamp: DEFAULT_TIMESTAMP,
+        voteYes: false,
+        weight: "100000",
+      })
+    ).toEqual({
+      choice: 0,
+      proposalId: DEFAULT_PROPOSAL_ID,
+      sig: "0x",
+      timestamp: 0,
+      type: "vote",
+      weight: "0",
+    });
+
+    // Member voted with `weight: "0"`
     expect(
       createVote({
         proposalId: DEFAULT_PROPOSAL_ID,
@@ -52,25 +124,7 @@ describe("createVote unit tests", () => {
       choice: 0,
       proposalId: DEFAULT_PROPOSAL_ID,
       sig: DEFAULT_SIG,
-      timestamp: 0,
-      type: "vote",
-      weight: "0",
-    });
-
-    // Somehow a member voted with `weight: "0"`
-    expect(
-      createVote({
-        proposalId: DEFAULT_PROPOSAL_ID,
-        sig: "0x",
-        timestamp: 0,
-        voteYes: false,
-        weight: "0",
-      })
-    ).toEqual({
-      choice: 0,
-      proposalId: DEFAULT_PROPOSAL_ID,
-      sig: "0x",
-      timestamp: 0,
+      timestamp: DEFAULT_TIMESTAMP,
       type: "vote",
       weight: "0",
     });
@@ -161,6 +215,7 @@ describe("createVote unit tests", () => {
     };
 
     const defaultReturnData = {
+      choice: 0,
       proposalId: DEFAULT_PROPOSAL_ID,
       sig: "0x",
       timestamp: 0,
@@ -175,7 +230,6 @@ describe("createVote unit tests", () => {
       })
     ).toEqual({
       ...defaultReturnData,
-      choice: 0,
       weight: "0",
     });
 
@@ -188,7 +242,6 @@ describe("createVote unit tests", () => {
       })
     ).toEqual({
       ...defaultReturnData,
-      choice: 0,
       weight: "0",
     });
 
@@ -201,12 +254,44 @@ describe("createVote unit tests", () => {
       })
     ).toEqual({
       ...defaultReturnData,
-      choice: 0,
+      weight: "0",
+    });
+
+    // Weight provided is `"0"`
+    expect(
+      createVote({
+        ...defaultArgs,
+        weight: "0",
+      })
+    ).toEqual({
+      ...defaultReturnData,
+      weight: "0",
+    });
+
+    // Weight provided is empty
+    expect(
+      createVote({
+        ...defaultArgs,
+        weight: "",
+      })
+    ).toEqual({
+      ...defaultReturnData,
+      weight: "0",
+    });
+
+    // Weight provided is is empty space
+    expect(
+      createVote({
+        ...defaultArgs,
+        weight: " ",
+      })
+    ).toEqual({
+      ...defaultReturnData,
       weight: "0",
     });
   });
 
-  test('should return `weight` as `"0" if voted, but there is no (or bad) weight`', () => {
+  test('voted: should return `weight` as `"0" if no (or bad) weight`', () => {
     const defaultArgs = {
       proposalId: DEFAULT_PROPOSAL_ID,
       sig: DEFAULT_SIG,
@@ -217,7 +302,7 @@ describe("createVote unit tests", () => {
     const defaultReturnData = {
       proposalId: DEFAULT_PROPOSAL_ID,
       sig: DEFAULT_SIG,
-      timestamp: 0,
+      timestamp: DEFAULT_TIMESTAMP,
       type: "vote",
     };
 
@@ -268,101 +353,9 @@ describe("createVote unit tests", () => {
       choice: 0,
       weight: "0",
     });
-
-    // Weight is OK, but `sig: "0x"`
-    expect(
-      createVote({
-        ...defaultArgs,
-        sig: "0x",
-        weight: "100000",
-      })
-    ).toEqual({
-      ...defaultReturnData,
-      choice: 0,
-      sig: "0x",
-      weight: "0",
-    });
-
-    // Weight is OK, but `sig` empty
-    expect(
-      createVote({
-        ...defaultArgs,
-        sig: "",
-        weight: "100000",
-      })
-    ).toEqual({
-      ...defaultReturnData,
-      choice: 0,
-      sig: "0x",
-      weight: "0",
-    });
-
-    // Weight is OK, but `sig` empty space
-    expect(
-      createVote({
-        ...defaultArgs,
-        sig: " ",
-        weight: "100000",
-      })
-    ).toEqual({
-      ...defaultReturnData,
-      choice: 0,
-      sig: "0x",
-      weight: "0",
-    });
   });
 
-  test("should return positive integer for `timestamp`, if somehow negative", () => {
-    const defaultArgs = {
-      proposalId: DEFAULT_PROPOSAL_ID,
-      sig: DEFAULT_SIG,
-      timestamp: DEFAULT_TIMESTAMP,
-      voteYes: true,
-      weight: "100000",
-    };
-
-    const defaultReturnData = {
-      proposalId: DEFAULT_PROPOSAL_ID,
-      sig: DEFAULT_SIG,
-      timestamp: DEFAULT_TIMESTAMP,
-      type: "vote",
-    };
-
-    // Negative `timestamp`
-    expect(
-      createVote({
-        ...defaultArgs,
-        timestamp: -DEFAULT_TIMESTAMP,
-      })
-    ).toEqual({
-      ...defaultReturnData,
-      choice: 1,
-      timestamp: DEFAULT_TIMESTAMP,
-      weight: "100000",
-    });
-  });
-
-  test("should return trimmed `sig`", () => {
-    // Space added to `sig`
-    expect(
-      createVote({
-        proposalId: DEFAULT_PROPOSAL_ID,
-        sig: ` ${DEFAULT_SIG}   `,
-        timestamp: DEFAULT_TIMESTAMP,
-        voteYes: true,
-        weight: "100000",
-      })
-    ).toEqual({
-      choice: 1,
-      proposalId: DEFAULT_PROPOSAL_ID,
-      sig: DEFAULT_SIG,
-      timestamp: DEFAULT_TIMESTAMP,
-      type: "vote",
-      weight: "100000",
-    });
-  });
-
-  test("should return `timestamp` as `0` if no `weight` or `sig`", () => {
+  test("should return `timestamp` as `0` if no `weight` and/or `sig`", () => {
     const defaultArgs = {
       proposalId: DEFAULT_PROPOSAL_ID,
       timestamp: DEFAULT_TIMESTAMP,
@@ -421,7 +414,11 @@ describe("createVote unit tests", () => {
         sig: DEFAULT_SIG,
         weight: "0",
       })
-    ).toEqual({ ...defaultReturnData, sig: DEFAULT_SIG });
+    ).toEqual({
+      ...defaultReturnData,
+      sig: DEFAULT_SIG,
+      timestamp: DEFAULT_TIMESTAMP,
+    });
 
     // When weight is `"-100000"` and `sig` is OK
     expect(
@@ -430,7 +427,11 @@ describe("createVote unit tests", () => {
         sig: DEFAULT_SIG,
         weight: "0",
       })
-    ).toEqual({ ...defaultReturnData, sig: DEFAULT_SIG });
+    ).toEqual({
+      ...defaultReturnData,
+      sig: DEFAULT_SIG,
+      timestamp: DEFAULT_TIMESTAMP,
+    });
 
     // When weight is empty and `sig` is OK
     expect(
@@ -439,7 +440,11 @@ describe("createVote unit tests", () => {
         sig: DEFAULT_SIG,
         weight: "",
       })
-    ).toEqual({ ...defaultReturnData, sig: DEFAULT_SIG });
+    ).toEqual({
+      ...defaultReturnData,
+      sig: DEFAULT_SIG,
+      timestamp: DEFAULT_TIMESTAMP,
+    });
 
     // When weight is empty space and `sig` is OK
     expect(
@@ -448,7 +453,61 @@ describe("createVote unit tests", () => {
         sig: DEFAULT_SIG,
         weight: "",
       })
-    ).toEqual({ ...defaultReturnData, sig: DEFAULT_SIG });
+    ).toEqual({
+      ...defaultReturnData,
+      sig: DEFAULT_SIG,
+      timestamp: DEFAULT_TIMESTAMP,
+    });
+  });
+
+  test("should return positive integer for `timestamp`, if somehow negative", () => {
+    const defaultArgs = {
+      proposalId: DEFAULT_PROPOSAL_ID,
+      sig: DEFAULT_SIG,
+      timestamp: DEFAULT_TIMESTAMP,
+      voteYes: true,
+      weight: "100000",
+    };
+
+    const defaultReturnData = {
+      proposalId: DEFAULT_PROPOSAL_ID,
+      sig: DEFAULT_SIG,
+      timestamp: DEFAULT_TIMESTAMP,
+      type: "vote",
+    };
+
+    // Negative `timestamp`
+    expect(
+      createVote({
+        ...defaultArgs,
+        timestamp: -DEFAULT_TIMESTAMP,
+      })
+    ).toEqual({
+      ...defaultReturnData,
+      choice: 1,
+      timestamp: DEFAULT_TIMESTAMP,
+      weight: "100000",
+    });
+  });
+
+  test("should return trimmed `sig`", () => {
+    // Space added to `sig`
+    expect(
+      createVote({
+        proposalId: DEFAULT_PROPOSAL_ID,
+        sig: ` ${DEFAULT_SIG}   `,
+        timestamp: DEFAULT_TIMESTAMP,
+        voteYes: true,
+        weight: "100000",
+      })
+    ).toEqual({
+      choice: 1,
+      proposalId: DEFAULT_PROPOSAL_ID,
+      sig: DEFAULT_SIG,
+      timestamp: DEFAULT_TIMESTAMP,
+      type: "vote",
+      weight: "100000",
+    });
   });
 
   test("should throw if `timestamp` evaluates to `NaN`", () => {

--- a/tests/createVote.unit.test.ts
+++ b/tests/createVote.unit.test.ts
@@ -1,9 +1,4 @@
-import {
-  DEFAULT_ETH_ADDRESS,
-  DEFAULT_PROPOSAL_ID,
-  DEFAULT_SIG,
-  DEFAULT_TIMESTAMP,
-} from "./utils";
+import { DEFAULT_PROPOSAL_ID, DEFAULT_SIG, DEFAULT_TIMESTAMP } from "./utils";
 import { createVote } from "../index";
 
 describe("createVote unit tests", () => {
@@ -57,7 +52,7 @@ describe("createVote unit tests", () => {
       choice: 0,
       proposalId: DEFAULT_PROPOSAL_ID,
       sig: DEFAULT_SIG,
-      timestamp: DEFAULT_TIMESTAMP,
+      timestamp: 0,
       type: "vote",
       weight: "0",
     });
@@ -83,7 +78,6 @@ describe("createVote unit tests", () => {
 
   test("no vote: should return correct `choice`, `weight` data if `weight` is falsy, or wrong type", () => {
     const defaultArgs = {
-      memberAddress: DEFAULT_ETH_ADDRESS,
       proposalId: DEFAULT_PROPOSAL_ID,
       sig: "0x",
       timestamp: 0,
@@ -153,14 +147,173 @@ describe("createVote unit tests", () => {
       })
     ).toEqual({
       ...defaultReturnData,
-      choice: 1,
-      weight: "100000",
+      choice: 0,
+      weight: "0",
+    });
+  });
+
+  test('no vote: `weight` should be `"0"`', () => {
+    const defaultArgs = {
+      proposalId: DEFAULT_PROPOSAL_ID,
+      sig: "0x",
+      timestamp: 0,
+      voteYes: true,
+    };
+
+    const defaultReturnData = {
+      proposalId: DEFAULT_PROPOSAL_ID,
+      sig: "0x",
+      timestamp: 0,
+      type: "vote",
+    };
+
+    // Weight provided is `"100000"`
+    expect(
+      createVote({
+        ...defaultArgs,
+        weight: "100000",
+      })
+    ).toEqual({
+      ...defaultReturnData,
+      choice: 0,
+      weight: "0",
+    });
+
+    // Weight provided is `"100000"`, `sig` is empty
+    expect(
+      createVote({
+        ...defaultArgs,
+        sig: "",
+        weight: "100000",
+      })
+    ).toEqual({
+      ...defaultReturnData,
+      choice: 0,
+      weight: "0",
+    });
+
+    // Weight provided is `"100000"`, `sig` is empty space
+    expect(
+      createVote({
+        ...defaultArgs,
+        sig: " ",
+        weight: "100000",
+      })
+    ).toEqual({
+      ...defaultReturnData,
+      choice: 0,
+      weight: "0",
+    });
+  });
+
+  test('should return `weight` as `"0" if voted, but there is no (or bad) weight`', () => {
+    const defaultArgs = {
+      proposalId: DEFAULT_PROPOSAL_ID,
+      sig: DEFAULT_SIG,
+      timestamp: DEFAULT_TIMESTAMP,
+      voteYes: true,
+    };
+
+    const defaultReturnData = {
+      proposalId: DEFAULT_PROPOSAL_ID,
+      sig: DEFAULT_SIG,
+      timestamp: 0,
+      type: "vote",
+    };
+
+    // Weight is `"0"`
+    expect(
+      createVote({
+        ...defaultArgs,
+        weight: "0",
+      })
+    ).toEqual({
+      ...defaultReturnData,
+      choice: 0,
+      weight: "0",
+    });
+
+    // Weight is empty
+    expect(
+      createVote({
+        ...defaultArgs,
+        weight: "",
+      })
+    ).toEqual({
+      ...defaultReturnData,
+      choice: 0,
+      weight: "0",
+    });
+
+    // Weight is empty space
+    expect(
+      createVote({
+        ...defaultArgs,
+        weight: " ",
+      })
+    ).toEqual({
+      ...defaultReturnData,
+      choice: 0,
+      weight: "0",
+    });
+
+    // Weight is negative number string
+    expect(
+      createVote({
+        ...defaultArgs,
+        weight: "-100000",
+      })
+    ).toEqual({
+      ...defaultReturnData,
+      choice: 0,
+      weight: "0",
+    });
+
+    // Weight is OK, but `sig: "0x"`
+    expect(
+      createVote({
+        ...defaultArgs,
+        sig: "0x",
+        weight: "100000",
+      })
+    ).toEqual({
+      ...defaultReturnData,
+      choice: 0,
+      sig: "0x",
+      weight: "0",
+    });
+
+    // Weight is OK, but `sig` empty
+    expect(
+      createVote({
+        ...defaultArgs,
+        sig: "",
+        weight: "100000",
+      })
+    ).toEqual({
+      ...defaultReturnData,
+      choice: 0,
+      sig: "0x",
+      weight: "0",
+    });
+
+    // Weight is OK, but `sig` empty space
+    expect(
+      createVote({
+        ...defaultArgs,
+        sig: " ",
+        weight: "100000",
+      })
+    ).toEqual({
+      ...defaultReturnData,
+      choice: 0,
+      sig: "0x",
+      weight: "0",
     });
   });
 
   test("should return positive integer for `timestamp`, if somehow negative", () => {
     const defaultArgs = {
-      memberAddress: DEFAULT_ETH_ADDRESS,
       proposalId: DEFAULT_PROPOSAL_ID,
       sig: DEFAULT_SIG,
       timestamp: DEFAULT_TIMESTAMP,
@@ -189,9 +342,117 @@ describe("createVote unit tests", () => {
     });
   });
 
+  test("should return trimmed `sig`", () => {
+    // Space added to `sig`
+    expect(
+      createVote({
+        proposalId: DEFAULT_PROPOSAL_ID,
+        sig: ` ${DEFAULT_SIG}   `,
+        timestamp: DEFAULT_TIMESTAMP,
+        voteYes: true,
+        weight: "100000",
+      })
+    ).toEqual({
+      choice: 1,
+      proposalId: DEFAULT_PROPOSAL_ID,
+      sig: DEFAULT_SIG,
+      timestamp: DEFAULT_TIMESTAMP,
+      type: "vote",
+      weight: "100000",
+    });
+  });
+
+  test("should return `timestamp` as `0` if no `weight` or `sig`", () => {
+    const defaultArgs = {
+      proposalId: DEFAULT_PROPOSAL_ID,
+      timestamp: DEFAULT_TIMESTAMP,
+      voteYes: true,
+    };
+
+    const defaultReturnData = {
+      choice: 0,
+      proposalId: DEFAULT_PROPOSAL_ID,
+      sig: "0x",
+      timestamp: 0,
+      type: "vote",
+      weight: "0",
+    };
+
+    // When weight is `"0"` and `sig` is `"0x"`
+    expect(
+      createVote({
+        ...defaultArgs,
+        sig: "0x",
+        weight: "0",
+      })
+    ).toEqual(defaultReturnData);
+
+    // When weight is `"100000"` and `sig` is `"0x"`
+    expect(
+      createVote({
+        ...defaultArgs,
+        sig: "0x",
+        weight: "100000",
+      })
+    ).toEqual(defaultReturnData);
+
+    // When weight is `"100000"` and `sig` is empty
+    expect(
+      createVote({
+        ...defaultArgs,
+        sig: "",
+        weight: "100000",
+      })
+    ).toEqual(defaultReturnData);
+
+    // When weight is `"100000"` and `sig` is empty space
+    expect(
+      createVote({
+        ...defaultArgs,
+        sig: " ",
+        weight: "100000",
+      })
+    ).toEqual(defaultReturnData);
+
+    // When weight is `"0"` and `sig` is OK
+    expect(
+      createVote({
+        ...defaultArgs,
+        sig: DEFAULT_SIG,
+        weight: "0",
+      })
+    ).toEqual({ ...defaultReturnData, sig: DEFAULT_SIG });
+
+    // When weight is `"-100000"` and `sig` is OK
+    expect(
+      createVote({
+        ...defaultArgs,
+        sig: DEFAULT_SIG,
+        weight: "0",
+      })
+    ).toEqual({ ...defaultReturnData, sig: DEFAULT_SIG });
+
+    // When weight is empty and `sig` is OK
+    expect(
+      createVote({
+        ...defaultArgs,
+        sig: DEFAULT_SIG,
+        weight: "",
+      })
+    ).toEqual({ ...defaultReturnData, sig: DEFAULT_SIG });
+
+    // When weight is empty space and `sig` is OK
+    expect(
+      createVote({
+        ...defaultArgs,
+        sig: DEFAULT_SIG,
+        weight: "",
+      })
+    ).toEqual({ ...defaultReturnData, sig: DEFAULT_SIG });
+  });
+
   test("should throw if `timestamp` evaluates to `NaN`", () => {
     const defaultArgs = {
-      memberAddress: DEFAULT_ETH_ADDRESS,
       proposalId: DEFAULT_PROPOSAL_ID,
       sig: DEFAULT_SIG,
       timestamp: DEFAULT_TIMESTAMP,
@@ -209,7 +470,6 @@ describe("createVote unit tests", () => {
 
   test("should throw if `weight` evaluates to `NaN`", () => {
     const defaultArgs = {
-      memberAddress: DEFAULT_ETH_ADDRESS,
       proposalId: DEFAULT_PROPOSAL_ID,
       sig: DEFAULT_SIG,
       timestamp: DEFAULT_TIMESTAMP,


### PR DESCRIPTION
Fixes #28 

**Updates**

- `timestamp` is now set to `0` when no `sig`
- `weight` is properly set when no `sig`
- `weight` is properly set if `<= "0"` string provided
- `sig` is now trimmed to rule out false-positives for empty `String`
- Unit tests added and updated
- Improves comments