### PR TITLE
change `npm install->npm ci` in prod release GH Action

### DIFF
--- a/.github/workflows/prod-release.yaml
+++ b/.github/workflows/prod-release.yaml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '12'
-      - run: npm install
+      - run: npm ci
       #- run: npm test
       - name: Publish to NPM Registry
         uses: JS-DevTools/npm-publish@v1


### PR DESCRIPTION
This command is better for CI as it will install from the `package-lock`.